### PR TITLE
Make it go get-able

### DIFF
--- a/cmd/goclone/clone.go
+++ b/cmd/goclone/clone.go
@@ -3,10 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"mime"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strings"
 
 	"os/exec"
 
@@ -27,11 +27,14 @@ func cloneSite(ctx context.Context, args, cookies []string) error {
 	if len(cookies) != 0 {
 		cs = make([]*http.Cookie, 0, len(cookies))
 		for _, c := range cookies {
-			_, params, err := mime.ParseMediaType("cookie; " + c)
-			if err != nil {
-				return fmt.Errorf("cookie %q: %w", c, err)
-			}
-			for k, v := range params {
+			ff := strings.Fields(c)
+			for _, f := range ff {
+				var k, v string
+				if i := strings.IndexByte(f, '='); i >= 0 {
+					k, v = f[:i], strings.TrimRight(f[i+1:], ";")
+				} else {
+					return fmt.Errorf("No = in cookie %q", c)
+				}
 				cs = append(cs, &http.Cookie{Name: k, Value: v})
 			}
 		}

--- a/cmd/goclone/clone.go
+++ b/cmd/goclone/clone.go
@@ -1,4 +1,4 @@
-package goclone
+package main
 
 import (
 	"fmt"

--- a/cmd/goclone/clone.go
+++ b/cmd/goclone/clone.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"mime"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
 
 	"os/exec"
 
@@ -13,87 +18,70 @@ import (
 )
 
 // Clone the given site :)
-func cloneSite(args []string) {
-	url := args[0]
-
-	if Serve == true {
-		// grab the url from the
-		if !parser.ValidateURL(url) && !parser.ValidateDomain(url) {
-			fmt.Println("goclone <url>")
-		} else if parser.ValidateDomain(url) {
-			// use the domain as the project name
-			name := url
-			// CreateProject
-			projectPath := file.CreateProject(name)
-			// create the url
-			validURL := parser.CreateURL(name)
-			// Crawler
-			crawler.Crawl(validURL, projectPath)
-			// Restructure html
-			html.LinkRestructure(projectPath)
-			err := exec.Command("open", "http://localhost:5000").Start()
+func cloneSite(ctx context.Context, args, cookies []string) error {
+	jar, err := cookiejar.New(&cookiejar.Options{})
+	if err != nil {
+		return err
+	}
+	var cs []*http.Cookie
+	if len(cookies) != 0 {
+		cs = make([]*http.Cookie, 0, len(cookies))
+		for _, c := range cookies {
+			_, params, err := mime.ParseMediaType("cookie; " + c)
 			if err != nil {
-				panic(err)
+				return fmt.Errorf("cookie %q: %w", c, err)
 			}
-			server.Serve(projectPath)
-
-		} else if parser.ValidateURL(url) {
-			// get the hostname
-			name := parser.GetDomain(url)
-			// create project
-			projectPath := file.CreateProject(name)
-			// Crawler
-			crawler.Crawl(url, projectPath)
-			// Restructure html
-			html.LinkRestructure(projectPath)
-			err := exec.Command("open", "http://localhost:5000").Start()
-			if err != nil {
-				panic(err)
+			for k, v := range params {
+				cs = append(cs, &http.Cookie{Name: k, Value: v})
 			}
-			server.Serve(projectPath)
-		} else {
-			fmt.Print(url)
 		}
-	} else {
-		// grab the url from the
-		if !parser.ValidateURL(url) && !parser.ValidateDomain(url) {
-			fmt.Println("goclone <url>")
-		} else if parser.ValidateDomain(url) {
-			// use the domain as the project name
-			name := url
-			// CreateProject
-			projectPath := file.CreateProject(name)
-			// create the url
-			validURL := parser.CreateURL(name)
-			// Crawler
-			crawler.Crawl(validURL, projectPath)
-			// Restructure html
-			html.LinkRestructure(projectPath)
-			if Open {
-				// automatically open project
-				err := exec.Command("open", projectPath+"/index.html").Start()
-				if err != nil {
-					panic(err)
-				}
+		for _, a := range args {
+			u, err := url.Parse(a)
+			if err != nil {
+				return fmt.Errorf("%q: %w", a, err)
 			}
-
-		} else if parser.ValidateURL(url) {
-			// get the hostname
-			name := parser.GetDomain(url)
-			// create project
-			projectPath := file.CreateProject(name)
-			// Crawler
-			crawler.Crawl(url, projectPath)
-			// Restructure html
-			html.LinkRestructure(projectPath)
-			if Open {
-				err := exec.Command("open", projectPath+"/index.html").Start()
-				if err != nil {
-					panic(err)
-				}
-			}
-		} else {
-			fmt.Print(url)
+			jar.SetCookies(&url.URL{Scheme: u.Scheme, User: u.User, Host: u.Host}, cs)
 		}
 	}
+
+	var firstProject string
+	for _, u := range args {
+		isValid, isValidDomain := parser.ValidateURL(u), parser.ValidateDomain(u)
+		if !isValid && !isValidDomain {
+			return fmt.Errorf("%q is not valid", u)
+		}
+		name := u
+		if isValidDomain {
+			u = parser.CreateURL(name)
+		} else {
+			name = parser.GetDomain(u)
+		}
+		projectPath := file.CreateProject(name)
+		if firstProject == "" {
+			firstProject = projectPath
+		}
+
+		if err := crawler.Crawl(ctx, u, projectPath, crawler.SetCookieJar(jar)); err != nil {
+			return fmt.Errorf("%q: %w", u, err)
+		}
+		// Restructure html
+		if err := html.LinkRestructure(projectPath); err != nil {
+			return fmt.Errorf("%q: %w", projectPath, err)
+		}
+
+	}
+	if Serve {
+		cmd := exec.CommandContext(ctx, "open", "http://localhost:5000")
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("%v: %w", cmd.Args, err)
+		}
+		return server.Serve(firstProject)
+	} else if Open {
+		// automatically open project
+		cmd := exec.CommandContext(ctx, "open", firstProject+"/index.html")
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("%v: %w", cmd.Args, err)
+		}
+	}
+	return nil
 }

--- a/cmd/goclone/main.go
+++ b/cmd/goclone/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	Execute()
+}

--- a/cmd/goclone/root.go
+++ b/cmd/goclone/root.go
@@ -1,8 +1,9 @@
-package goclone
+package main
 
 import (
-	"github.com/spf13/cobra"
 	"log"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	"github.com/imthaghost/goclone/cmd/goclone"
-)
-
-func main() {
-	goclone.Execute()
-}

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -1,7 +1,13 @@
 package crawler
 
+import (
+	"context"
+
+	"github.com/gocolly/colly"
+)
+
 // Crawl asks the necessary crawlers for collecting links for building the web page
-func Crawl(site string, projectPath string) {
+func Crawl(ctx context.Context, site string, projectPath string, collyOpts ...func(*colly.Collector)) error {
 	// searches for css, js, and images within a given link
-	Collector(site, projectPath)
+	return Collector(ctx, site, projectPath, collyOpts...)
 }

--- a/pkg/html/sorter.go
+++ b/pkg/html/sorter.go
@@ -2,7 +2,7 @@ package html
 
 // LinkRestructure grabs all html files in project directory
 // reorganizes each file with local links (css js images)
-func LinkRestructure(projectDir string) {
+func LinkRestructure(projectDir string) error {
 	// Redirect JS/CSS/Img tags to the correct place :)
-	arrange(projectDir)
+	return arrange(projectDir)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Serve ...
-func Serve(projectPath string) {
+func Serve(projectPath string) error {
 	e := echo.New()
 	// Log Output
 	e.Use(middleware.Logger())
@@ -20,6 +20,5 @@ func Serve(projectPath string) {
 	e.Static("/", projectPath)
 	e.File("/", projectPath)
 
-	e.Logger.Fatal(e.Start(":5000"))
-
+	return e.Start(":5000")
 }


### PR DESCRIPTION
Make cmd/goclone go get-able,
and return errors instead of panic()ing,
use context.Context for cancelation.

Use as much as you wish.