### PR TITLE
Removing SSL-Check

### DIFF
--- a/pkg/crawler/html.go
+++ b/pkg/crawler/html.go
@@ -10,7 +10,8 @@ import (
 // HTMLExtractor ...
 func HTMLExtractor(link string, projectPath string) {
 	fmt.Println("Extracting --> ", link)
-
+	
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	// get the html body
 	resp, err := http.Get(link)
 	if err != nil {


### PR DESCRIPTION
Disabling the SSL-Check in /pkg/crawl/html.go, so Sites with custom generated or faulty ssl-certs can be cloned