### PR TITLE
Fix open in browser issue

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -82,7 +82,7 @@ func cloneSite(ctx context.Context, args []string) error {
 	} else if Open {
 		// automatically open project
 		cmd := exec.CommandContext(ctx, "open", firstProject+"/index.html")
-		if err := cmd.Start(); err != nil {
+		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("%v: %w", cmd.Args, err)
 		}
 	}

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -74,15 +74,15 @@ func cloneSite(ctx context.Context, args []string) error {
 
 	}
 	if Serve {
-		cmd := exec.CommandContext(ctx, "open", "http://localhost:5000")
+		cmd := exec.Command("open", "http://localhost:5000")
 		if err := cmd.Start(); err != nil {
 			return fmt.Errorf("%v: %w", cmd.Args, err)
 		}
 		return server.Serve(firstProject)
 	} else if Open {
 		// automatically open project
-		cmd := exec.CommandContext(ctx, "open", firstProject+"/index.html")
-		if err := cmd.Run(); err != nil {
+		cmd := exec.Command("open", firstProject+"/index.html")
+		if err := cmd.Start(); err != nil {
 			return fmt.Errorf("%v: %w", cmd.Args, err)
 		}
 	}


### PR DESCRIPTION
I suspect that what was happening was that the cli process terminated before the open process. 
With the [Run method](https://pkg.go.dev/os/exec#Cmd.Run), it is forced to wait for the open process to finish.