### PR TITLE
This change is to allow the serve port to be tweaked.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Flags:
   -o, --open                  Automatically open project in default browser
   -p, --proxy_string string   Proxy connection string. Support http and socks5 https://pkg.go.dev/github.com/gocolly/colly#Collector.SetProxy
   -s, --serve                 Serve the generated files using Echo.
+  -P, --servePort int         Serve port number. (default 5000)
   -u, --user_agent string     Custom User Agent
 ```
 

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"os/exec"
@@ -75,7 +74,8 @@ func cloneSite(ctx context.Context, args []string) error {
 
 	}
 	if Serve {
-		cmd := exec.Command("open", "http://localhost:"+strconv.Itoa(ServePort))
+		serverUrl := fmt.Sprintf("http://localhost:%d", ServePort)
+		cmd := exec.Command("open", serverUrl)
 		if err := cmd.Start(); err != nil {
 			return fmt.Errorf("%v: %w", cmd.Args, err)
 		}

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"os/exec"
@@ -74,11 +75,11 @@ func cloneSite(ctx context.Context, args []string) error {
 
 	}
 	if Serve {
-		cmd := exec.Command("open", "http://localhost:5000")
+		cmd := exec.Command("open", "http://localhost:"+strconv.Itoa(ServePort))
 		if err := cmd.Start(); err != nil {
 			return fmt.Errorf("%v: %w", cmd.Args, err)
 		}
-		return server.Serve(firstProject)
+		return server.Serve(firstProject, ServePort)
 	} else if Open {
 		// automatically open project
 		cmd := exec.Command("open", firstProject+"/index.html")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 var (
 	Open        bool
 	Serve       bool
+	ServePort   int
 	UserAgent   string
 	ProxyString string
 	Cookies     []string
@@ -49,6 +50,7 @@ func Execute() {
 	pf.BoolVarP(&Open, "open", "o", false, "Automatically open project in deafult browser")
 	// rootCmd.PersistentFlags().BoolVarP(&Login, "login", "l", false, "Wether to use a username or password")
 	pf.BoolVarP(&Serve, "serve", "s", false, "Serve the generated files using Echo.")
+	pf.IntVarP(&ServePort, "servePort", "P", 5000, "Serve port number.")
 	pf.StringVarP(&ProxyString, "proxy_string", "p", "", "Proxy connection string. Support http and socks5 https://pkg.go.dev/github.com/gocolly/colly#Collector.SetProxy")
 	pf.StringVarP(&UserAgent, "user_agent", "u", "", "Custom User Agent")
 	rootCmd.Flags().StringSliceVarP(&Cookies, "cookie", "C", nil, "Pre-set these cookies")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,9 +1,9 @@
 package server
 
 import (
+	"fmt"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
-	"strconv"
 )
 
 // Serve ...
@@ -21,5 +21,5 @@ func Serve(projectPath string, port int) error {
 	e.Static("/", projectPath)
 	e.File("/", projectPath)
 
-	return e.Start(":" + strconv.Itoa(port))
+	return e.Start(fmt.Sprintf(":%d", port))
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,10 +3,11 @@ package server
 import (
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
+	"strconv"
 )
 
 // Serve ...
-func Serve(projectPath string) error {
+func Serve(projectPath string, port int) error {
 	e := echo.New()
 	// Log Output
 	e.Use(middleware.Logger())
@@ -20,5 +21,5 @@ func Serve(projectPath string) error {
 	e.Static("/", projectPath)
 	e.File("/", projectPath)
 
-	return e.Start(":5000")
+	return e.Start(":" + strconv.Itoa(port))
 }


### PR DESCRIPTION
For example, should we want to clone https://goclone.io and serve on port 8080: 
```
goclone -s -P 8080 https://www.goclone.io/
```