### PR TITLE
Serve generated website on non desktop linux distributions.

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -76,7 +76,7 @@ func cloneSite(ctx context.Context, args []string) error {
 	}
 	if Serve {
 		serverUrl := fmt.Sprintf("http://localhost:%d", ServePort)
-		cmd := exec.Command("open", serverUrl)
+		cmd := open(serverUrl)
 		if err := cmd.Start(); err != nil {
 			return fmt.Errorf("%v: %w", cmd.Args, err)
 		}
@@ -103,7 +103,11 @@ func open(url string) *exec.Cmd {
 	case "darwin":
 		cmd = "open"
 	default: // "linux", "freebsd", "openbsd", "netbsd"
-		cmd = "xdg-open"
+		if _, err := exec.LookPath("xdg-open"); err != nil {
+			cmd = "echo"
+		}else {
+			cmd = "xdg-open"
+		}
 	}
 	args = append(args, url)
 	return exec.Command(cmd, args...)


### PR DESCRIPTION
On non desktop linux distributions the serve and the open options fail because XDG is not installed so the call to "xdg-open" command results in an error. This causes a fatal error before the echo server is launched to serve the generated page.

It also seems that the multi OS option for the serve flag introduced in #51 was lost by changes from #48.