### PR TITLE
fix(server): solve close server issue.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,7 +1,11 @@
 package server
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -10,17 +14,39 @@ import (
 // Serve ...
 func Serve(projectPath string, port int) error {
 	e := echo.New()
+
 	// Log Output
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
+
 	// CORS
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"*"},
 		AllowMethods: []string{echo.GET, echo.HEAD, echo.PUT, echo.PATCH, echo.POST, echo.DELETE},
 	}))
+
 	// static files
 	e.Static("/", projectPath)
 	e.File("/", projectPath)
 
-	return e.Start(fmt.Sprintf(":%d", port))
+	// Create a context that can be cancelled
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Start the server in a goroutine
+	go func() {
+		if err := e.Start(fmt.Sprintf(":%d", port)); err != nil {
+			e.Logger.Info("Shutting down the server")
+		}
+	}()
+
+	// Wait for the interrupt signal
+	<-ctx.Done()
+
+	// Graceful shutdown of the server
+	if err := e.Shutdown(context.Background()); err != nil {
+		e.Logger.Fatal(err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
# 🔧 Fix: Graceful Server Shutdown on Ctrl+C

This PR implements proper signal handling for the Echo server when running with the `-s` flag:

✨ Changes:
- Added graceful shutdown handling for SIGINT (Ctrl+C) and SIGTERM signals
- Implemented context-based cancellation for clean server termination
- Added proper logging during server shutdown
- Moved server startup to a separate goroutine for better control

🎯 Purpose:
Previously, the server would not properly shutdown when using Ctrl+C with the `-s` flag. This fix ensures that all connections are properly closed and the server shuts down gracefully when interrupted.

🧪 Testing:
To test this change:
1. Run goclone with the `-s` flag
2. Press Ctrl+C
3. Verify that the server shuts down cleanly with proper logging