### PR TITLE
fix: preserve original filename when saving assets

### DIFF
--- a/pkg/parser/extension.go
+++ b/pkg/parser/extension.go
@@ -1,39 +1,18 @@
 package parser
 
 import (
+	"net/url"
 	"path"
 )
 
 // URLExtension returns the extension from a given URL, or an empty string
 func URLExtension(URL string) string {
-	/*
-		>>> https://tesla.com/main.css
-		<<< ".css"
-
-		>>> https://tesla.com/main.css?Asf341
-		<<< ".css"
-
-		>>> https://dribbble.com/css/home
-		<<< ""
-	*/
-
-	// get the raw extension from the URL
-	ext := path.Ext(URL)
-	// fmt.Println(ext)
-
-	// check if the extension has more than 5 characters, we need to remove any excess
-	if len(ext) > 5 {
-		// for every index and letter after the 0 index (ext[0] is ".", we want to keep that)
-		for i, char := range ext[1:] {
-			// if the unicode value of the char is not within the bounds alpha chars
-			if !('a' <= char && char <= 'z') || ('A' <= char && char <= 'Z') {
-				// reinitialize the ext to only include the characters for the extension and break
-				ext = ext[:i+1]
-				break
-			}
-		}
+	// Parse the URL
+	u, err := url.Parse(URL)
+	if err != nil {
+		return ""
 	}
 
-	// // return the extension
-	return ext
+	// Get the path and extract the extension
+	return path.Ext(u.Path)
 }

--- a/pkg/parser/url_extension_test.go
+++ b/pkg/parser/url_extension_test.go
@@ -12,10 +12,49 @@ func TestURLExtension(t *testing.T) {
 		url      string
 		expected string
 	}{
+		// Basic cases
 		{"https://tesla.com/main.css", ".css"},
+		{"https://tesla.com/main.js", ".js"},
+		{"https://tesla.com/image.jpg", ".jpg"},
+		{"https://tesla.com/image.png", ".png"},
+		{"https://tesla.com/image.svg", ".svg"},
+
+		// Cases with query parameters
 		{"https://tesla.com/main.css?Asf341", ".css"},
+		{"https://tesla.com/main.css?ver=1.0", ".css"},
+		{"https://tesla.com/main.css?ver=1.0&type=min", ".css"},
+
+		// Cases with fragments
+		{"https://tesla.com/main.css#section", ".css"},
+		{"https://tesla.com/main.css#top", ".css"},
+
+		// Combined cases
+		{"https://tesla.com/main.css?ver=1.0#section", ".css"},
+		{"https://tesla.com/main.min.js?ver=1.0#section", ".js"},
+
+		// Cases without extension
 		{"https://dribbble.com/css/home", ""},
+		{"https://example.com/path/to/file", ""},
+		{"https://example.com/path/to/file/", ""},
+
+		// Cases with multiple dots
+		{"https://example.com/file.min.js", ".js"},
+		{"https://example.com/file.min.css", ".css"},
+
+		// Cases with long paths
+		{"https://example.com/path/to/file.min.js", ".js"},
+		{"https://example.com/path/to/deep/file.min.css", ".css"},
+
+		// Cases with special characters
+		{"https://example.com/file-name.min.js", ".js"},
+		{"https://example.com/file_name.min.css", ".css"},
+
+		// Cases with malformed URLs
+		{"", ""},
+		{"not-a-url", ""},
+		{"http://", ""},
 	}
+
 	for _, table := range tables {
 		result := URLExtension(table.url)
 		expectedresult := table.expected
@@ -23,7 +62,6 @@ func TestURLExtension(t *testing.T) {
 			t.Error()
 			red := color.New(color.FgRed).SprintFunc()
 			fmt.Printf("%s URLExtension Failed: %s , expected %s got %s \n", red("[-]"), table.url, expectedresult, result)
-
 		} else {
 			green := color.New(color.FgGreen).SprintFunc()
 			fmt.Printf("%s URLExtension Passing: %s \n", green("[+]"), table.url)


### PR DESCRIPTION
# Fix asset filename preservation during extraction

## Previous behavior
When extracting assets (like JavaScript files), the code was modifying the original filenames by:
1. Taking the base name
2. Removing the old extension
3. Adding a new extension

For example, a file named `frontend.min.js?ver=3.11.5` would be saved as:
- Original URL: `https://example.com/assets/frontend.min.js?ver=3.11.5`
- Was being saved as: `frontend.js`
- Leading to 404 errors when the page tried to load the original filename

## New behavior
The extraction process now:
1. Preserves the original filename (excluding query parameters)
2. Stores it in the correct asset directory
3. Maintains the complete filename structure

Same example now:
- Original URL: `https://example.com/assets/frontend.min.js?ver=3.11.5`
- Now saved as: `frontend.min.js`
- Resolves the 404 errors as the filename matches what the page expects

## Changes
- Simplified `writeFileToPath` function to use original filenames
- Removed unnecessary filename manipulation logic
- Added proper path handling with `filepath.Join`
- Improved directory creation handling